### PR TITLE
fix(event listeners): remove event listeners on umount

### DIFF
--- a/src/Picky.js
+++ b/src/Picky.js
@@ -46,7 +46,11 @@ class Picky extends React.PureComponent {
   componentDidMount() {
     this.focusFilterInput(this.state.open);
   }
-
+  
+  componentWillUnmount() {
+    document.removeEventListener('click', this.handleOutsideClick, false);
+  }
+  
   UNSAFE_componentWillReceiveProps(nextProps) {
     if (
       this.props.options !== nextProps.options ||


### PR DESCRIPTION
I ran into the the following error when writing tests for a component that uses react-picky

>     console.error node_modules/react-dom/cjs/react-dom.development.js:520
>       Warning: Can't call setState (or forceUpdate) on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.
>           in Picky (created by ElementsSelect)
>           in ElementsSelect

I have 2 tests. The first one opened the options to verify they were being fetched and rendered. I didn't think to simulate a click elsewhere to close the popup so on my second test, when i click to open the popup, the event listener from the first test was being called.

My tests for reference:

```jsx
describe('ElementsSelect', () => {
  afterEach(() => {
    fetchElementTypes.mockReset()
  })
  it('should render fetched options', async () => {
    fetchElementTypes.mockReturnValue(Promise.resolve(['foo', 'bar']))
    const {container, getByText} = render(<ElementsSelect onChange={jest.fn()} />)
    const button = container.querySelector('button')
    fireEvent.click(button)
    await waitForElement(() => getByText('foo'))
    await waitForElement(() => getByText('bar'))
  })
  it('should call on change', async () => {
    const onChange = jest.fn()
    fetchElementTypes.mockReturnValue(Promise.resolve(['foo', 'baz']))
    const {container, getByText} = render(<ElementsSelect onChange={onChange} />)
    const button = container.querySelector('button')
    fireEvent.click(button) // <-- calls event listener from previous test
    const barOption = await waitForElement(() => getByText('baz'))
    fireEvent.click(barOption)
    expect(onChange).toHaveBeenCalledTimes(1)
    expect(onChange.mock.calls[0][0]).toEqual(['baz'])
  })
})
```
