### PR TITLE
fix: placeholder className, default 'id' prop

### DIFF
--- a/src/Picky.js
+++ b/src/Picky.js
@@ -468,6 +468,7 @@ class Picky extends React.PureComponent {
 }
 
 Picky.defaultProps = {
+  id: 'picky',
   numberDisplayed: 3,
   options: [],
   filterDebounce: 150,

--- a/src/Placeholder.js
+++ b/src/Placeholder.js
@@ -64,7 +64,7 @@ const Placeholder = ({
 
   return (
     <span
-      className={isEmptyValue(value) && 'picky__placeholder'}
+      className={isEmptyValue(value) ? 'picky__placeholder' : undefined}
       data-testid="picky_placeholder"
     >
       {message}


### PR DESCRIPTION
This PR addresses the following two React warnings:

> Warning: Failed prop type: The prop `id` is marked as required in `Picky`, but its value is `undefined`

> Received false for a non-boolean attribute className.
> If you used to conditionally omit it with className={condition && value}, pass className={condition ? value : undefined} instead.