### PR TITLE
fix(placeholder): set "picky__placeholder"  with a non-empty value

### DIFF
--- a/src/Placeholder.tsx
+++ b/src/Placeholder.tsx
@@ -82,7 +82,7 @@ const Placeholder: React.FC<PlaceholderProps> = ({
 
   return (
     <span
-      className={isEmptyValue(value) ? 'picky__placeholder' : undefined}
+      className={!isEmptyValue(value) ? 'picky__placeholder' : undefined}
       data-testid="picky_placeholder"
     >
       {message}

--- a/src/__tests__/Placeholder.test.tsx
+++ b/src/__tests__/Placeholder.test.tsx
@@ -112,7 +112,10 @@ describe('Placeholder', () => {
     const { getByTestId } = render(
       //@ts-ignore
       <Placeholder
-        value={[{ id: 1, name: 'Item 1' }, { id: 2, name: 'Item 2' }]}
+        value={[
+          { id: 1, name: 'Item 1' },
+          { id: 2, name: 'Item 2' },
+        ]}
         multiple={true}
         labelKey="name"
         valueKey="id"
@@ -134,5 +137,14 @@ describe('Placeholder', () => {
     );
     const placeholder = getByTestId(PLACEHOLDER_TESTID);
     expect(placeholder.textContent).toEqual('Item 1');
+  });
+
+  it('should set class "picky__placeholder" with a non-empty value', () => {
+    const { getByTestId } = render(
+      //@ts-ignore
+      <Placeholder value={'one'} />
+    );
+    const placeholder = getByTestId(PLACEHOLDER_TESTID);
+    expect(placeholder.className).toEqual('picky__placeholder');
   });
 });


### PR DESCRIPTION
#193  Note
fixed set class `picky__placeholder`  in the playholder when selecting items
