### PR TITLE
fix: strict mode compliance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,11 @@ addons:
       # Ubuntu 16+ does not install this dependency by default, so we need to install it ourselves
       - libgconf-2-4
 cache:
-  npm: true
   directories:
     - ~/.npm
     - node_modules
     - ~/.cache
-install: yarn install & yarn prepare-example
+install: yarn install && yarn prepare-example
 notifications:
   email: false
 node_js:

--- a/src/Picky.tsx
+++ b/src/Picky.tsx
@@ -333,13 +333,11 @@ class Picky extends React.PureComponent<PickyProps, PickyState> {
     this.focusFilterInput = this.focusFilterInput.bind(this);
     this.getValue = this.getValue.bind(this);
   }
-  UNSAFE_componentWillMount() {
+
+  componentDidMount() {
     this.setState({
       allSelected: this.allSelected(),
     });
-  }
-
-  componentDidMount() {
     this.focusFilterInput(!!this.state.open);
   }
 
@@ -347,32 +345,31 @@ class Picky extends React.PureComponent<PickyProps, PickyState> {
     document.removeEventListener('click', this.handleOutsideClick, false);
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps: PickyProps) {
+  componentDidUpdate(prevProps: PickyProps) {
     if (
-      this.props.options !== nextProps.options ||
-      this.props.value !== nextProps.value
+      this.props.options !== prevProps.options ||
+      this.props.value !== prevProps.value
     ) {
-      let valuesEqual = Array.isArray(nextProps.value)
-        ? arraysEqual(nextProps.value, this.props.value as OptionsType)
-        : nextProps.value === this.props.value;
+      if (!this.props.multiple) return;
+      let valuesEqual = Array.isArray(prevProps.value)
+        ? arraysEqual(prevProps.value, this.props.value as OptionsType)
+        : prevProps.value === this.props.value;
 
-      let optsEqual = arraysEqual(nextProps.options, this.props.options);
+      let optsEqual = arraysEqual(prevProps.options, this.props.options);
       const currentOptions = this.state.filtered
         ? this.state.filteredOptions
-        : nextProps.options;
+        : this.props.options;
       const currentValues = this.state.filtered
         ? this.state.filteredOptions.filter(value => {
-            if (Array.isArray(nextProps.value)) {
-              return nextProps.value.includes(value);
+            if (Array.isArray(this.props.value)) {
+              return this.props.value.includes(value);
             }
             return true;
           })
-        : nextProps.value;
+        : this.props.value;
       this.setState({
         allSelected: !(valuesEqual && optsEqual)
-          ? // FIXME
-            //@ts-ignore
-            this.allSelected(currentValues, currentOptions)
+          ? this.allSelected(currentValues as OptionsType, currentOptions)
           : this.allSelected(),
       });
     }

--- a/src/__tests__/Picky.test.tsx
+++ b/src/__tests__/Picky.test.tsx
@@ -852,10 +852,10 @@ describe('Picky', () => {
       });
     });
 
-    describe('Issue #38', () => {
-      test('should set selectedValue state when async value prop updates', done => {
+    describe('Issue #39', () => {
+      test('should set selectedValue state when async value prop updates', () => {
         const mockOnChange = jest.fn();
-        const { rerender } = render(
+        const { rerender, getAllByTestId } = render(
           <Picky
             {...corePickyProps}
             multiple
@@ -865,26 +865,20 @@ describe('Picky', () => {
             onChange={mockOnChange}
           />
         );
-        const componentWillUpdateSpy = jest.spyOn(
-          Picky.prototype,
-          'UNSAFE_componentWillReceiveProps'
+
+        rerender(
+          <Picky
+            {...corePickyProps}
+            multiple
+            open
+            value={['1', '2']}
+            options={['1', '2', '3', '4', '5']}
+            onChange={mockOnChange}
+          />
         );
-        setTimeout(() => {
-          rerender(
-            <Picky
-              {...corePickyProps}
-              multiple
-              open
-              value={['1', '2']}
-              options={['1', '2', '3', '4', '5']}
-              onChange={mockOnChange}
-            />
-          );
-          expect(componentWillUpdateSpy).toHaveBeenCalled();
-          componentWillUpdateSpy.mockReset();
-          componentWillUpdateSpy.mockRestore();
-          done();
-        }, 20);
+
+        const options = getAllByTestId('option');
+        expect(options).toHaveLength(5);
       });
       test('with async value when selecting option should not unselect all other options', done => {
         const onChangeMock = jest.fn();


### PR DESCRIPTION
### Note
Picky currently isn't strict mode compliant. I've removed the deprecated lifecycle methods. 
