### PR TITLE
feat: add single singleSelectPlaceholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Picky.propTypes = {
   buttonProps: PropTypes.object,
   selectAllMode: PropTypes.oneOf(['default', 'filtered']),
   clearFilterOnClose: PropTypes.bool,
+  singleSelectPlaceholder: PropTypes.func,
 };
 ```
 
@@ -178,6 +179,7 @@ Picky.propTypes = {
 - `selectAllMode` - default: `default`. When the mode is `filtered` the Select All won't be hidden when filtering.
 - `clearFilterOnClose` - When set to true filtered options and filtered state will be cleared on close. Defaults to false.
 - `filterTermProcessor` - A function that takes a string and returns a string. Useful for trimming and processing a filter term before it filters the options. Default: (term) => term
+- `singleSelectPlaceholder` - A function that takes the currently selected value and returns a string. `(val: OptionType) => string`
 
 ## Custom rendering
 

--- a/src/Picky.tsx
+++ b/src/Picky.tsx
@@ -296,6 +296,11 @@ export type PickyProps = {
    * @type {StringFunc}
    */
   filterTermProcessor?: (term: string) => string;
+
+  /**
+   * A call back to render the placeholder for single select. Must return a string.
+   */
+  singleSelectPlaceholder?: (value: OptionsType) => string;
 };
 
 class Picky extends React.PureComponent<PickyProps, PickyState> {
@@ -754,6 +759,7 @@ class Picky extends React.PureComponent<PickyProps, PickyState> {
             placeholder={placeholder}
             manySelectedPlaceholder={this.props.manySelectedPlaceholder}
             allSelectedPlaceholder={this.props.allSelectedPlaceholder}
+            singleSelectPlaceholder={this.props.singleSelectPlaceholder}
             value={value}
             multiple={Boolean(multiple)}
             numberDisplayed={numberDisplayed!}

--- a/src/Placeholder.tsx
+++ b/src/Placeholder.tsx
@@ -25,6 +25,7 @@ type PlaceholderProps = {
   manySelectedPlaceholder?: string;
   allSelectedPlaceholder?: string;
   allSelected: SelectionState;
+  singleSelectPlaceholder?: (value: OptionsType) => string;
 };
 const Placeholder: React.FC<PlaceholderProps> = React.memo(
   ({
@@ -36,6 +37,7 @@ const Placeholder: React.FC<PlaceholderProps> = React.memo(
     labelKey,
     manySelectedPlaceholder,
     allSelectedPlaceholder,
+    singleSelectPlaceholder,
     allSelected,
   }) => {
     let message: string = '';
@@ -71,7 +73,9 @@ const Placeholder: React.FC<PlaceholderProps> = React.memo(
         }
       } else {
         let tempValue = Array.isArray(value) ? value[0] : value;
-        if (isDataObject(tempValue, valueKey, labelKey)) {
+        if (typeof singleSelectPlaceholder === 'function') {
+          message = singleSelectPlaceholder(tempValue);
+        } else if (isDataObject(tempValue, valueKey, labelKey)) {
           message = (tempValue as ComplexOptionType)[labelKey!];
         } else {
           message = String(tempValue as SimpleOptionType);

--- a/src/__tests__/Picky.test.tsx
+++ b/src/__tests__/Picky.test.tsx
@@ -166,6 +166,81 @@ describe('Picky', () => {
       );
       expect(getByTestId('picky_placeholder').textContent).toEqual('1');
     });
+
+    it('should show single select placeholder if single select and is defined', () => {
+      const singlePlaceholder = (val: any) => `You have selected ${val}`;
+      const { getByTestId, rerender } = render(
+        <Picky
+          {...corePickyProps}
+          value={2}
+          options={[1, 2, 3, 4, 5]}
+          open={true}
+          multiple={false}
+          singleSelectPlaceholder={singlePlaceholder}
+        />
+      );
+
+      expect(getByTestId('picky_placeholder').textContent).toEqual(
+        'You have selected 2'
+      );
+
+      rerender(
+        <Picky
+          {...corePickyProps}
+          value={3}
+          options={[1, 2, 3, 4, 5]}
+          open={true}
+          multiple={false}
+          singleSelectPlaceholder={singlePlaceholder}
+        />
+      );
+      expect(getByTestId('picky_placeholder').textContent).toEqual(
+        'You have selected 3'
+      );
+    });
+    it('should show single select placeholder if single select and is defined with object value', () => {
+      const singlePlaceholder = (val: any) => `You have selected ${val.label}`;
+      const { getByTestId, rerender } = render(
+        <Picky
+          {...corePickyProps}
+          value={{ value: 1, label: 'One' }}
+          options={[
+            { value: 1, label: 'One' },
+            { value: 2, label: 'Two' },
+            { value: 3, label: 'Three' },
+          ]}
+          labelKey="label"
+          valueKey="value"
+          open={true}
+          multiple={false}
+          singleSelectPlaceholder={singlePlaceholder}
+        />
+      );
+
+      expect(getByTestId('picky_placeholder').textContent).toEqual(
+        'You have selected One'
+      );
+
+      rerender(
+        <Picky
+          {...corePickyProps}
+          value={{ value: 1, label: 'Three' }}
+          options={[
+            { value: 1, label: 'One' },
+            { value: 2, label: 'Two' },
+            { value: 3, label: 'Three' },
+          ]}
+          labelKey="label"
+          valueKey="value"
+          open={true}
+          multiple={false}
+          singleSelectPlaceholder={singlePlaceholder}
+        />
+      );
+      expect(getByTestId('picky_placeholder').textContent).toEqual(
+        'You have selected Three'
+      );
+    });
     it('should show correct placeholder with selected value, multi select', () => {
       const { getByTestId, rerender } = render(
         <Picky


### PR DESCRIPTION
### Note

Closes #216 

Add a callback prop `singleSelectPlaceholder` for customising how single select values are displayed in the placeholder. 

